### PR TITLE
Save fid50k snapshots as labeled images

### DIFF
--- a/gen_images.py
+++ b/gen_images.py
@@ -71,7 +71,7 @@ def generate_images(
     # Generate images.
     for seed_idx, seed in enumerate(seeds):
         print('Generating image for seed %d (%d/%d) ...' % (seed, seed_idx, len(seeds)))
-        z = torch.from_numpy(np.random.RandomState(seed).randn(1, G.z_dim)).to(device)
+        z = torch.from_numpy(np.random.RandomState(seed).randn(1, G.z_dim).astype(np.float32)).to(device)
         img = G(z, label)
         img = (img.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
         PIL.Image.fromarray(img[0].cpu().numpy(), 'RGB').save(f'{outdir}/seed{seed:04d}.png')

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -98,6 +98,27 @@ def save_image_grid(img, fname, drange, grid_size):
 
 #----------------------------------------------------------------------------
 
+def save_image_folder(img, labels, dirname, drange):
+    lo, hi = drange
+    img = np.asarray(img, dtype=np.float32)
+    img = (img - lo) * (255 / (hi - lo))
+    img = np.rint(img).clip(0, 255).astype(np.uint8)
+
+    os.makedirs(dirname, exist_ok=True)
+    N, C, H, W = img.shape
+    img = img.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+    labels = np.asarray(labels)
+
+    for idx in range(N):
+        im = img[idx]
+        label_idx = int(labels[idx].argmax() if labels.ndim > 1 else labels[idx])
+        if C == 1:
+            PIL.Image.fromarray(im[:, :, 0], 'L').save(os.path.join(dirname, f'{idx:05d}_c{label_idx}.png'))
+        else:
+            PIL.Image.fromarray(im, 'RGB').save(os.path.join(dirname, f'{idx:05d}_c{label_idx}.png'))
+
+#----------------------------------------------------------------------------
+
 def remap_optimizer_state_dict(state_dict, device):
     state_dict = copy.deepcopy(state_dict)
     for param in state_dict['state'].values():
@@ -244,7 +265,10 @@ def training_loop(
         grid_z = torch.randn([labels.shape[0], G.z_dim], device=device).split(g_batch_gpu)
         grid_c = torch.from_numpy(labels).to(device).split(g_batch_gpu)
         images = torch.cat([G_ema(z, c).cpu() for z, c in zip(grid_z, grid_c)]).to(torch.float).numpy()
-        save_image_grid(images, os.path.join(run_dir, 'fakes_init.png'), drange=[-1,1], grid_size=grid_size)
+        if 'fid50k_full' in metrics:
+            save_image_folder(images, labels, os.path.join(run_dir, 'fakes_init'), drange=[-1,1])
+        else:
+            save_image_grid(images, os.path.join(run_dir, 'fakes_init.png'), drange=[-1,1], grid_size=grid_size)
 
     # Initialize logs.
     if rank == 0:
@@ -396,7 +420,11 @@ def training_loop(
         # Save image snapshot.
         if (rank == 0) and (image_snapshot_ticks is not None) and (done or cur_tick % image_snapshot_ticks == 0):
             images = torch.cat([G_ema(z, c).cpu() for z, c in zip(grid_z, grid_c)]).to(torch.float).numpy()
-            save_image_grid(images, os.path.join(run_dir, f'fakes{cur_nimg//1000:09d}.png'), drange=[-1,1], grid_size=grid_size)
+            if 'fid50k_full' in metrics:
+                labels_np = np.concatenate([c.cpu().numpy() for c in grid_c], axis=0)
+                save_image_folder(images, labels_np, os.path.join(run_dir, f'fakes{cur_nimg//1000:09d}'), drange=[-1,1])
+            else:
+                save_image_grid(images, os.path.join(run_dir, f'fakes{cur_nimg//1000:09d}.png'), drange=[-1,1], grid_size=grid_size)
 
         # Save network snapshot.
         snapshot_pkl = None


### PR DESCRIPTION
## Summary
- snapshot helper now records labels with each image
- export init snapshots to folder when using `fid50k_full`
- include class labels in per-image snapshot files

## Testing
- `python -m py_compile gen_images.py training/training_loop.py`


------
https://chatgpt.com/codex/tasks/task_e_68466d93e9608330977fff2ad8692415